### PR TITLE
Ignore updates to Markdown files in CI workflows

### DIFF
--- a/.github/workflows/run-tests-linux.yml
+++ b/.github/workflows/run-tests-linux.yml
@@ -3,7 +3,11 @@ name: Run tests on Linux
 on:
   push:
     branches: [ master ]
+    paths-ignore:
+        - '**.md'
   pull_request:
+    paths-ignore:
+        - '**.md'
 
 concurrency:
   # In master we want to run for every commit, in other branches — only for the last one


### PR DESCRIPTION
We don't want to run tests, if only Markdown files were changed.