### PR TITLE
Move SSZ-related code into private headers

### DIFF
--- a/libs/data_types/CMakeLists.txt
+++ b/libs/data_types/CMakeLists.txt
@@ -1,22 +1,8 @@
-# SSZ++ requires C++23
-set(CMAKE_CXX_STANDARD 23)
-set(CMAKE_CXX_STANDARD_REQUIRED True)
-
-find_package(Hashtree REQUIRED)
-find_package(sszpp REQUIRED)
-
 set(LIBRARY_NAME zkEVMDataTypes)
-set(SOURCES
-    src/account.cpp
-    src/account_block.cpp
-    src/block.cpp
-    src/block_header.cpp
-    src/message.cpp
-    src/state.cpp
-    src/transaction.cpp
-    src/transaction_receipt.cpp)
 
-add_library(${LIBRARY_NAME} STATIC ${SOURCES})
+add_library(${LIBRARY_NAME} STATIC)
+
+add_subdirectory(src)
 
 set(PUBLIC_HEADERS_PREFIX zkevm_framework/data_types)
 set(PUBLIC_HEADERS
@@ -34,12 +20,11 @@ set(PUBLIC_HEADERS
 set_target_properties(${LIBRARY_NAME} PROPERTIES PUBLIC_HEADER "${PUBLIC_HEADERS}")
 
 target_include_directories(${LIBRARY_NAME}
+    PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/src
     PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
-
-target_link_libraries(${LIBRARY_NAME} INTERFACE sszpp)
-target_link_libraries(${LIBRARY_NAME} PRIVATE hashtree)
 
 install(TARGETS ${LIBRARY_NAME}
     PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${PUBLIC_HEADERS_PREFIX}

--- a/libs/data_types/include/zkevm_framework/data_types/account.hpp
+++ b/libs/data_types/include/zkevm_framework/data_types/account.hpp
@@ -8,7 +8,6 @@
 
 #include <cstdint>
 
-#include "sszpp/ssz++.hpp"
 #include "zkevm_framework/data_types/base.hpp"
 
 namespace data_types {
@@ -29,27 +28,6 @@ namespace data_types {
 
         /// @brief deserizalize from SSZ
         static Account deserialize(const bytes &src);
-
-      private:
-        struct Serializable : ssz::ssz_container {
-            size_t m_nonce;
-            size_t m_balance;
-            uint8_t m_accessStatus;
-
-            SSZ_CONT(m_nonce, m_balance, m_accessStatus)
-
-            Serializable() {}
-
-            Serializable(const Account &account)
-                : m_nonce(account.m_nonce),
-                  m_balance(account.m_balance),
-                  m_accessStatus(account.m_accessStatus) {}
-        };
-
-        Account(const Serializable &s)
-            : m_balance(s.m_balance),
-              m_nonce(s.m_nonce),
-              m_accessStatus(static_cast<AccessStatus>(s.m_accessStatus)) {}
     };
 }  // namespace data_types
 

--- a/libs/data_types/include/zkevm_framework/data_types/account_block.hpp
+++ b/libs/data_types/include/zkevm_framework/data_types/account_block.hpp
@@ -6,7 +6,6 @@
 #ifndef ZKEMV_FRAMEWORK_LIBS_DATA_TYPES_INCLUDE_ZKEVM_FRAMEWORK_DATA_TYPES_ACCOUNT_BLOCK_HPP_
 #define ZKEMV_FRAMEWORK_LIBS_DATA_TYPES_INCLUDE_ZKEVM_FRAMEWORK_DATA_TYPES_ACCOUNT_BLOCK_HPP_
 
-#include "sszpp/ssz++.hpp"
 #include "zkevm_framework/data_types/base.hpp"
 #include "zkevm_framework/data_types/mpt.hpp"
 #include "zkevm_framework/data_types/transaction.hpp"
@@ -28,20 +27,6 @@ namespace data_types {
 
         /// @brief deserizalize from SSZ
         static AccountBlock deserialize(const bytes &src);
-
-      private:
-        struct Serializable : ssz::ssz_variable_size_container {
-            Address m_accountAddress;
-            ssz::list<Transaction::Serializable, 100> m_transactions;
-
-            SSZ_CONT(m_accountAddress, m_transactions)
-
-            Serializable() {}
-
-            Serializable(const AccountBlock &account_block);
-        };
-
-        AccountBlock(const Serializable &s);
     };
 }  // namespace data_types
 

--- a/libs/data_types/include/zkevm_framework/data_types/block.hpp
+++ b/libs/data_types/include/zkevm_framework/data_types/block.hpp
@@ -6,7 +6,6 @@
 #ifndef ZKEMV_FRAMEWORK_LIBS_DATA_TYPES_INCLUDE_ZKEVM_FRAMEWORK_DATA_TYPES_BLOCK_HPP_
 #define ZKEMV_FRAMEWORK_LIBS_DATA_TYPES_INCLUDE_ZKEVM_FRAMEWORK_DATA_TYPES_BLOCK_HPP_
 
-#include "sszpp/ssz++.hpp"
 #include "zkevm_framework/data_types/account_block.hpp"
 #include "zkevm_framework/data_types/base.hpp"
 #include "zkevm_framework/data_types/block_header.hpp"
@@ -37,23 +36,6 @@ namespace data_types {
 
         /// @brief deserizalize from SSZ
         static Block deserialize(const bytes &src);
-
-      private:
-        struct Serializable : ssz::ssz_variable_size_container {
-            ssz::list<AccountBlock::Serializable, 100> m_accountBlocks;
-            ssz::list<InMsg::Serializable, 100> m_inputMsgs;
-            ssz::list<OutMsg::Serializable, 100> m_outputMsgs;
-            BlockHeader::Serializable m_previousBlock;
-            BlockHeader::Serializable m_currentBlock;
-
-            SSZ_CONT(m_accountBlocks, m_inputMsgs, m_outputMsgs, m_previousBlock, m_currentBlock)
-
-            Serializable() {}
-
-            Serializable(const Block &block);
-        };
-
-        Block(const Serializable &s);
     };
 }  // namespace data_types
 

--- a/libs/data_types/include/zkevm_framework/data_types/block_header.hpp
+++ b/libs/data_types/include/zkevm_framework/data_types/block_header.hpp
@@ -8,9 +8,7 @@
 
 #include <cstdint>
 
-#include "sszpp/ssz++.hpp"
 #include "zkevm_framework/data_types/base.hpp"
-#include "zkevm_framework/data_types/transaction.hpp"
 
 namespace data_types {
     /// @brief Block header.
@@ -56,52 +54,6 @@ namespace data_types {
 
         /// @brief deserizalize from SSZ
         static BlockHeader deserialize(const bytes& src);
-
-      private:
-        struct Serializable : ssz::ssz_variable_size_container {
-            Hash m_parentHash;
-            size_t m_number;
-            size_t m_gasLimit;
-            size_t m_gasUsed;
-            Address m_coinbase;
-            size_t m_prevrandao;
-            size_t m_chain_id;
-            size_t m_basefee;
-            size_t m_blob_basefee;
-            ssz::list<std::byte, 100> m_extraData;
-            size_t m_timestamp;
-
-            SSZ_CONT(m_parentHash, m_number, m_gasLimit, m_gasUsed, m_coinbase, m_prevrandao,
-                     m_chain_id, m_basefee, m_blob_basefee, m_extraData, m_timestamp)
-
-            Serializable() {}
-
-            Serializable(const BlockHeader& header)
-                : m_parentHash(header.m_parentHash),
-                  m_number(header.m_number),
-                  m_gasLimit(header.m_gasLimit),
-                  m_gasUsed(header.m_gasUsed),
-                  m_coinbase(header.m_coinbase),
-                  m_prevrandao(header.m_prevrandao),
-                  m_chain_id(header.m_chain_id),
-                  m_basefee(header.m_basefee),
-                  m_blob_basefee(header.m_basefee),
-                  m_extraData(header.m_extraData),
-                  m_timestamp(header.m_timestamp) {}
-        };
-
-        BlockHeader(const Serializable& s)
-            : m_parentHash(s.m_parentHash),
-              m_number(s.m_number),
-              m_gasLimit(s.m_gasLimit),
-              m_gasUsed(s.m_gasUsed),
-              m_coinbase(s.m_coinbase),
-              m_prevrandao(s.m_prevrandao),
-              m_chain_id(s.m_chain_id),
-              m_basefee(s.m_basefee),
-              m_blob_basefee(s.m_basefee),
-              m_extraData(s.m_extraData.begin(), s.m_extraData.end()),
-              m_timestamp(s.m_timestamp) {}
     };
 }  // namespace data_types
 

--- a/libs/data_types/include/zkevm_framework/data_types/message.hpp
+++ b/libs/data_types/include/zkevm_framework/data_types/message.hpp
@@ -6,7 +6,6 @@
 #ifndef ZKEMV_FRAMEWORK_LIBS_DATA_TYPES_INCLUDE_ZKEVM_FRAMEWORK_DATA_TYPES_MESSAGE_HPP_
 #define ZKEMV_FRAMEWORK_LIBS_DATA_TYPES_INCLUDE_ZKEVM_FRAMEWORK_DATA_TYPES_MESSAGE_HPP_
 
-#include "sszpp/ssz++.hpp"
 #include "zkevm_framework/data_types/base.hpp"
 #include "zkevm_framework/data_types/transaction.hpp"
 
@@ -28,22 +27,6 @@ namespace data_types {
 
         /// @brief deserizalize from SSZ
         static CommonMsgInfo deserialize(const bytes& src);
-
-      private:
-        struct Serializable : ssz::ssz_container {
-            Address m_src;
-            Address m_dst;
-            size_t m_value;
-
-            SSZ_CONT(m_src, m_dst, m_value)
-
-            Serializable() {}
-
-            Serializable(const CommonMsgInfo& info)
-                : m_src(info.m_src), m_dst(info.m_dst), m_value(info.m_value) {}
-        };
-
-        CommonMsgInfo(const Serializable& s) : m_src(s.m_src), m_dst(s.m_dst), m_value(s.m_value) {}
     };
 
     class InMsg {
@@ -61,20 +44,6 @@ namespace data_types {
 
         /// @brief deserizalize from SSZ
         static InMsg deserialize(const bytes& src);
-
-      private:
-        struct Serializable : ssz::ssz_variable_size_container {
-            CommonMsgInfo::Serializable m_info;
-            Transaction::Serializable m_transaction;
-
-            SSZ_CONT(m_info, m_transaction)
-
-            Serializable() {}
-
-            Serializable(const InMsg& msg) : m_info(msg.m_info), m_transaction(msg.m_transaction) {}
-        };
-
-        InMsg(const Serializable& s) : m_info(s.m_info), m_transaction(s.m_transaction) {}
     };
 
     class OutMsg {
@@ -93,21 +62,6 @@ namespace data_types {
 
         /// @brief deserizalize from SSZ
         static OutMsg deserialize(const bytes& src);
-
-      private:
-        struct Serializable : ssz::ssz_variable_size_container {
-            CommonMsgInfo::Serializable m_info;
-            Transaction::Serializable m_transaction;
-
-            SSZ_CONT(m_info, m_transaction)
-
-            Serializable() {}
-
-            Serializable(const OutMsg& msg)
-                : m_info(msg.m_info), m_transaction(msg.m_transaction) {}
-        };
-
-        OutMsg(const Serializable& s) : m_info(s.m_info), m_transaction(s.m_transaction) {}
     };
 }  // namespace data_types
 

--- a/libs/data_types/include/zkevm_framework/data_types/state.hpp
+++ b/libs/data_types/include/zkevm_framework/data_types/state.hpp
@@ -8,7 +8,6 @@
 
 #include <cstdint>
 
-#include "sszpp/ssz++.hpp"
 #include "zkevm_framework/data_types/account.hpp"
 #include "zkevm_framework/data_types/base.hpp"
 #include "zkevm_framework/data_types/message.hpp"
@@ -53,32 +52,6 @@ namespace data_types {
 
         /// @brief deserizalize from SSZ
         static State deserialize(const bytes &src);
-
-      private:
-        struct Serializable : ssz::ssz_variable_size_container {
-            uint64_t m_globalId;
-            uint64_t m_shardId;
-            uint32_t m_seqNo;
-            uint64_t m_vertSeqNo;
-            size_t m_genLt;
-            uint32_t m_minRefMcSeqno;
-            bool m_beforeSplit;
-            uint32_t m_genUtime;
-            uint32_t m_totalBalance;
-            uint32_t m_totalValidatorFees;
-            ssz::list<OutMsg::Serializable, 100> m_outMsg;
-            ssz::list<Account::Serializable, 100> m_accounts;
-
-            SSZ_CONT(m_globalId, m_shardId, m_seqNo, m_vertSeqNo, m_genLt, m_minRefMcSeqno,
-                     m_beforeSplit, m_genUtime, m_totalBalance, m_totalValidatorFees, m_outMsg,
-                     m_accounts)
-
-            Serializable() {}
-
-            Serializable(const State &state);
-        };
-
-        State(const Serializable &s);
     };
 }  // namespace data_types
 

--- a/libs/data_types/include/zkevm_framework/data_types/transaction.hpp
+++ b/libs/data_types/include/zkevm_framework/data_types/transaction.hpp
@@ -8,7 +8,6 @@
 
 #include <cstdint>
 
-#include "sszpp/ssz++.hpp"
 #include "zkevm_framework/data_types/base.hpp"
 
 namespace data_types {
@@ -50,46 +49,6 @@ namespace data_types {
 
         /// @brief deserizalize from SSZ
         static Transaction deserialize(const bytes& src);
-
-      private:
-        struct Serializable : ssz::ssz_variable_size_container {
-            size_t m_id;
-            uint8_t m_type;
-            size_t m_nonce;
-            size_t m_value;
-            Address m_receiveAddress;
-            size_t m_gasPrice;
-            size_t m_gas;
-            ssz::list<std::byte, 100> m_data;
-            Address m_sender;
-
-            SSZ_CONT(m_id, m_type, m_nonce, m_value, m_receiveAddress, m_gasPrice, m_gas, m_data,
-                     m_sender)
-
-            Serializable() {}
-
-            Serializable(const Transaction& transaction)
-                : m_id(transaction.m_id),
-                  m_nonce(transaction.m_nonce),
-                  m_value(transaction.m_value),
-                  m_receiveAddress(transaction.m_receiveAddress),
-                  m_gasPrice(transaction.m_gasPrice),
-                  m_gas(transaction.m_gas),
-                  m_sender(transaction.m_sender),
-                  m_type(transaction.m_type),
-                  m_data(transaction.m_data) {}
-        };
-
-        Transaction(const Serializable& s)
-            : m_id(s.m_id),
-              m_nonce(s.m_nonce),
-              m_value(s.m_value),
-              m_receiveAddress(s.m_receiveAddress),
-              m_gasPrice(s.m_gasPrice),
-              m_gas(s.m_gas),
-              m_sender(s.m_sender),
-              m_type(static_cast<Type>(s.m_type)),
-              m_data(s.m_data.begin(), s.m_data.end()) {}
     };
 }  // namespace data_types
 

--- a/libs/data_types/include/zkevm_framework/data_types/transaction_receipt.hpp
+++ b/libs/data_types/include/zkevm_framework/data_types/transaction_receipt.hpp
@@ -8,7 +8,6 @@
 
 #include <cstdint>
 
-#include "sszpp/ssz++.hpp"
 #include "zkevm_framework/data_types/base.hpp"
 #include "zkevm_framework/data_types/transaction.hpp"
 
@@ -31,27 +30,6 @@ namespace data_types {
 
         /// @brief deserizalize from SSZ
         static TransactionReceipt deserialize(const bytes& src);
-
-      private:
-        struct Serializable : ssz::ssz_container {
-            uint8_t m_type;
-            Hash m_stateRoot;
-            size_t m_gasUsed;
-
-            SSZ_CONT(m_type, m_stateRoot, m_gasUsed)
-
-            Serializable() {}
-
-            Serializable(const TransactionReceipt& receipt)
-                : m_type(receipt.m_type),
-                  m_stateRoot(receipt.m_stateRoot),
-                  m_gasUsed(receipt.m_gasUsed) {}
-        };
-
-        TransactionReceipt(const Serializable& s)
-            : m_type(static_cast<Transaction::Type>(s.m_type)),
-              m_stateRoot(s.m_stateRoot),
-              m_gasUsed(s.m_gasUsed) {}
     };
 }  // namespace data_types
 

--- a/libs/data_types/src/CMakeLists.txt
+++ b/libs/data_types/src/CMakeLists.txt
@@ -1,0 +1,28 @@
+# SSZ++ can be compiled only with GCC 13+
+if(NOT CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    message(FATAL_ERROR "Data types library can be built only with GCC 13+")
+endif()
+if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 13.0)
+    message(FATAL_ERROR "Data types library can be built only with GCC 13+")
+endif()
+
+# SSZ++ requires C++23
+set_target_properties(${LIBRARY_NAME} PROPERTIES CXX_STANDARD 23)
+
+find_package(Hashtree REQUIRED)
+find_package(sszpp REQUIRED)
+
+set(SOURCES
+    account.cpp
+    account_block.cpp
+    block.cpp
+    block_header.cpp
+    message.cpp
+    state.cpp
+    transaction.cpp
+    transaction_receipt.cpp)
+
+target_sources(${LIBRARY_NAME} PRIVATE ${SOURCES})
+
+target_link_libraries(${LIBRARY_NAME} INTERFACE sszpp)
+target_link_libraries(${LIBRARY_NAME} PRIVATE hashtree)

--- a/libs/data_types/src/account.cpp
+++ b/libs/data_types/src/account.cpp
@@ -1,12 +1,15 @@
 #include "zkevm_framework/data_types/account.hpp"
 
+#include "containers/account.hpp"
 #include "sszpp/ssz++.hpp"
 #include "zkevm_framework/data_types/base.hpp"
 
 namespace data_types {
-    bytes Account::serialize() const { return ssz::serialize<Account::Serializable>(*this); }
+    using namespace containers;
+
+    bytes Account::serialize() const { return ssz::serialize<AccountContainer>(*this); }
 
     Account Account::deserialize(const bytes& src) {
-        return ssz::deserialize<Account::Serializable>(src);
+        return static_cast<Account>(ssz::deserialize<AccountContainer>(src));
     }
 }  // namespace data_types

--- a/libs/data_types/src/account_block.cpp
+++ b/libs/data_types/src/account_block.cpp
@@ -1,28 +1,17 @@
 #include "zkevm_framework/data_types/account_block.hpp"
 
+#include "containers/account_block.hpp"
 #include "sszpp/ssz++.hpp"
 #include "zkevm_framework/data_types/base.hpp"
+#include "zkevm_framework/data_types/mpt.hpp"
 #include "zkevm_framework/data_types/transaction.hpp"
 
 namespace data_types {
-    AccountBlock::Serializable::Serializable(const AccountBlock& account_block)
-        : m_accountAddress(account_block.m_accountAddress) {
-        for (const Transaction& transaction : account_block.m_transactions) {
-            m_transactions.push_back(Transaction::Serializable(transaction));
-        }
-    }
+    using namespace containers;
 
-    AccountBlock::AccountBlock(const Serializable& s) : m_accountAddress(s.m_accountAddress) {
-        for (const Transaction::Serializable& transaction : s.m_transactions) {
-            m_transactions.push_back(Transaction(transaction));
-        }
-    }
-
-    bytes AccountBlock::serialize() const {
-        return ssz::serialize<AccountBlock::Serializable>(*this);
-    }
+    bytes AccountBlock::serialize() const { return ssz::serialize<AccountBlockContainer>(*this); }
 
     AccountBlock AccountBlock::deserialize(const bytes& src) {
-        return ssz::deserialize<AccountBlock::Serializable>(src);
+        return static_cast<AccountBlock>(ssz::deserialize<AccountBlockContainer>(src));
     }
 }  // namespace data_types

--- a/libs/data_types/src/block.cpp
+++ b/libs/data_types/src/block.cpp
@@ -1,40 +1,15 @@
 #include "zkevm_framework/data_types/block.hpp"
 
-#include "zkevm_framework/data_types/account_block.hpp"
+#include "containers/block.hpp"
+#include "sszpp/ssz++.hpp"
 #include "zkevm_framework/data_types/base.hpp"
-#include "zkevm_framework/data_types/transaction.hpp"
-#include "zkevm_framework/data_types/transaction_receipt.hpp"
 
 namespace data_types {
-    Block::Serializable::Serializable(const Block& block)
-        : m_previousBlock(block.m_previousBlock), m_currentBlock(block.m_currentBlock) {
-        for (const AccountBlock& account_block : block.m_accountBlocks) {
-            m_accountBlocks.push_back(AccountBlock::Serializable(account_block));
-        }
-        for (const InMsg& in_msg : block.m_inputMsgs) {
-            m_inputMsgs.push_back(InMsg::Serializable(in_msg));
-        }
-        for (const OutMsg& out_msg : block.m_outputMsgs) {
-            m_outputMsgs.push_back(OutMsg::Serializable(out_msg));
-        }
-    }
+    using namespace containers;
 
-    Block::Block(const Block::Serializable& s)
-        : m_previousBlock(s.m_previousBlock), m_currentBlock(s.m_currentBlock) {
-        for (const AccountBlock::Serializable& account_block : s.m_accountBlocks) {
-            m_accountBlocks.push_back(AccountBlock(account_block));
-        }
-        for (const InMsg& in_msg : s.m_inputMsgs) {
-            m_inputMsgs.push_back(InMsg(in_msg));
-        }
-        for (const OutMsg& out_msg : s.m_outputMsgs) {
-            m_outputMsgs.push_back(OutMsg(out_msg));
-        }
-    }
-
-    bytes Block::serialize() const { return ssz::serialize<Block::Serializable>(*this); }
+    bytes Block::serialize() const { return ssz::serialize<BlockContainer>(*this); }
 
     Block Block::deserialize(const bytes& src) {
-        return ssz::deserialize<Block::Serializable>(src);
+        return static_cast<Block>(ssz::deserialize<BlockContainer>(src));
     }
 }  // namespace data_types

--- a/libs/data_types/src/block_header.cpp
+++ b/libs/data_types/src/block_header.cpp
@@ -1,14 +1,15 @@
 #include "zkevm_framework/data_types/block_header.hpp"
 
+#include "containers/block_header.hpp"
 #include "sszpp/ssz++.hpp"
 #include "zkevm_framework/data_types/base.hpp"
 
 namespace data_types {
-    bytes BlockHeader::serialize() const {
-        return ssz::serialize<BlockHeader::Serializable>(*this);
-    }
+    using namespace containers;
+
+    bytes BlockHeader::serialize() const { return ssz::serialize<BlockHeaderContainer>(*this); }
 
     BlockHeader BlockHeader::deserialize(const bytes& src) {
-        return ssz::deserialize<BlockHeader::Serializable>(src);
+        return static_cast<BlockHeader>(ssz::deserialize<BlockHeaderContainer>(src));
     }
 }  // namespace data_types

--- a/libs/data_types/src/containers/account.hpp
+++ b/libs/data_types/src/containers/account.hpp
@@ -1,0 +1,33 @@
+#ifndef ZKEMV_FRAMEWORK_LIBS_DATA_TYPES_SRC_CONTAINERS_ACCOUNT_HPP_
+#define ZKEMV_FRAMEWORK_LIBS_DATA_TYPES_SRC_CONTAINERS_ACCOUNT_HPP_
+
+#include <cstdint>
+
+#include "sszpp/ssz++.hpp"
+#include "zkevm_framework/data_types/account.hpp"
+#include "zkevm_framework/data_types/base.hpp"
+
+namespace data_types {
+    namespace containers {
+        struct AccountContainer : ssz::ssz_container {
+            size_t m_nonce;
+            size_t m_balance;
+            uint8_t m_accessStatus;
+
+            SSZ_CONT(m_nonce, m_balance, m_accessStatus)
+
+            AccountContainer() {}
+
+            AccountContainer(const Account &account)
+                : m_nonce(account.m_nonce),
+                  m_balance(account.m_balance),
+                  m_accessStatus(account.m_accessStatus) {}
+
+            operator Account() const {
+                return Account(m_nonce, m_balance, static_cast<AccessStatus>(m_accessStatus));
+            }
+        };
+    }  // namespace containers
+}  // namespace data_types
+
+#endif  // ZKEMV_FRAMEWORK_LIBS_DATA_TYPES_SRC_CONTAINERS_ACCOUNT_HPP_

--- a/libs/data_types/src/containers/account_block.hpp
+++ b/libs/data_types/src/containers/account_block.hpp
@@ -1,0 +1,39 @@
+#ifndef ZKEMV_FRAMEWORK_LIBS_DATA_TYPES_SRC_CONTAINERS_ACCOUNT_BLOCK_HPP_
+#define ZKEMV_FRAMEWORK_LIBS_DATA_TYPES_SRC_CONTAINERS_ACCOUNT_BLOCK_HPP_
+
+#include "containers/transaction.hpp"
+#include "sszpp/ssz++.hpp"
+#include "zkevm_framework/data_types/account_block.hpp"
+#include "zkevm_framework/data_types/base.hpp"
+#include "zkevm_framework/data_types/mpt.hpp"
+#include "zkevm_framework/data_types/transaction.hpp"
+
+namespace data_types {
+    namespace containers {
+        struct AccountBlockContainer : ssz::ssz_variable_size_container {
+            Address m_accountAddress;
+            ssz::list<TransactionContainer, 100> m_transactions;
+
+            SSZ_CONT(m_accountAddress, m_transactions)
+
+            AccountBlockContainer() {}
+
+            AccountBlockContainer(const AccountBlock& account_block)
+                : m_accountAddress(account_block.m_accountAddress) {
+                for (const Transaction& transaction : account_block.m_transactions) {
+                    m_transactions.push_back(TransactionContainer(transaction));
+                }
+            }
+
+            operator AccountBlock() const {
+                MPTNode<Transaction> transactions;
+                for (const TransactionContainer& transaction : m_transactions) {
+                    transactions.push_back(static_cast<Transaction>(transaction));
+                }
+                return AccountBlock(m_accountAddress, transactions);
+            }
+        };
+    }  // namespace containers
+}  // namespace data_types
+
+#endif  // ZKEMV_FRAMEWORK_LIBS_DATA_TYPES_SRC_CONTAINERS_ACCOUNT_BLOCK_HPP_

--- a/libs/data_types/src/containers/block.hpp
+++ b/libs/data_types/src/containers/block.hpp
@@ -1,0 +1,60 @@
+#ifndef ZKEMV_FRAMEWORK_LIBS_DATA_TYPES_SRC_CONTAINERS_BLOCK_HPP_
+#define ZKEMV_FRAMEWORK_LIBS_DATA_TYPES_SRC_CONTAINERS_BLOCK_HPP_
+
+#include "containers/account_block.hpp"
+#include "containers/block_header.hpp"
+#include "containers/message.hpp"
+#include "sszpp/ssz++.hpp"
+#include "zkevm_framework/data_types/account_block.hpp"
+#include "zkevm_framework/data_types/block.hpp"
+#include "zkevm_framework/data_types/message.hpp"
+#include "zkevm_framework/data_types/mpt.hpp"
+
+namespace data_types {
+    namespace containers {
+        struct BlockContainer : ssz::ssz_variable_size_container {
+            ssz::list<AccountBlockContainer, 100> m_accountBlocks;
+            ssz::list<InMsgContainer, 100> m_inputMsgs;
+            ssz::list<OutMsgContainer, 100> m_outputMsgs;
+            BlockHeaderContainer m_previousBlock;
+            BlockHeaderContainer m_currentBlock;
+
+            SSZ_CONT(m_accountBlocks, m_inputMsgs, m_outputMsgs, m_previousBlock, m_currentBlock)
+
+            BlockContainer() {}
+
+            BlockContainer(const Block& block)
+                : m_previousBlock(block.m_previousBlock), m_currentBlock(block.m_currentBlock) {
+                for (const AccountBlock& account_block : block.m_accountBlocks) {
+                    m_accountBlocks.push_back(AccountBlockContainer(account_block));
+                }
+                for (const InMsg& in_msg : block.m_inputMsgs) {
+                    m_inputMsgs.push_back(InMsgContainer(in_msg));
+                }
+                for (const OutMsg& out_msg : block.m_outputMsgs) {
+                    m_outputMsgs.push_back(OutMsgContainer(out_msg));
+                }
+            }
+
+            operator Block() const {
+                MPTNode<AccountBlock> accountBlocks;
+                for (const AccountBlockContainer& account_block : m_accountBlocks) {
+                    accountBlocks.push_back(static_cast<AccountBlock>(account_block));
+                }
+                MPTNode<InMsg> inputMsgs;
+                for (const InMsgContainer& in_msg : m_inputMsgs) {
+                    inputMsgs.push_back(static_cast<InMsg>(in_msg));
+                }
+                MPTNode<OutMsg> outputMsgs;
+                for (const OutMsgContainer& out_msg : m_outputMsgs) {
+                    outputMsgs.push_back(static_cast<OutMsg>(out_msg));
+                }
+                return Block(accountBlocks, inputMsgs, outputMsgs,
+                             static_cast<BlockHeader>(m_previousBlock),
+                             static_cast<BlockHeader>(m_currentBlock));
+            }
+        };
+    }  // namespace containers
+}  // namespace data_types
+
+#endif  // ZKEMV_FRAMEWORK_LIBS_DATA_TYPES_SRC_CONTAINERS_BLOCK_HPP_

--- a/libs/data_types/src/containers/block_header.hpp
+++ b/libs/data_types/src/containers/block_header.hpp
@@ -1,0 +1,53 @@
+#ifndef ZKEMV_FRAMEWORK_LIBS_DATA_TYPES_SRC_CONTAINERS_BLOCK_HEADER_HPP_
+#define ZKEMV_FRAMEWORK_LIBS_DATA_TYPES_SRC_CONTAINERS_BLOCK_HEADER_HPP_
+
+#include <cstddef>
+#include <cstdint>
+
+#include "sszpp/ssz++.hpp"
+#include "zkevm_framework/data_types/base.hpp"
+#include "zkevm_framework/data_types/block_header.hpp"
+
+namespace data_types {
+    namespace containers {
+        struct BlockHeaderContainer : ssz::ssz_variable_size_container {
+            Hash m_parentHash;
+            size_t m_number;
+            size_t m_gasLimit;
+            size_t m_gasUsed;
+            Address m_coinbase;
+            size_t m_prevrandao;
+            size_t m_chain_id;
+            size_t m_basefee;
+            size_t m_blob_basefee;
+            ssz::list<std::byte, 100> m_extraData;
+            size_t m_timestamp;
+
+            SSZ_CONT(m_parentHash, m_number, m_gasLimit, m_gasUsed, m_coinbase, m_prevrandao,
+                     m_chain_id, m_basefee, m_blob_basefee, m_extraData, m_timestamp)
+
+            BlockHeaderContainer() {}
+
+            BlockHeaderContainer(const BlockHeader& header)
+                : m_parentHash(header.m_parentHash),
+                  m_number(header.m_number),
+                  m_gasLimit(header.m_gasLimit),
+                  m_gasUsed(header.m_gasUsed),
+                  m_coinbase(header.m_coinbase),
+                  m_prevrandao(header.m_prevrandao),
+                  m_chain_id(header.m_chain_id),
+                  m_basefee(header.m_basefee),
+                  m_blob_basefee(header.m_basefee),
+                  m_extraData(header.m_extraData),
+                  m_timestamp(header.m_timestamp) {}
+
+            operator BlockHeader() const {
+                return BlockHeader(m_parentHash, m_number, m_gasLimit, m_gasUsed, m_coinbase,
+                                   m_prevrandao, m_chain_id, m_basefee, m_blob_basefee,
+                                   m_extraData.data(), m_timestamp);
+            }
+        };
+    }  // namespace containers
+}  // namespace data_types
+
+#endif  // ZKEMV_FRAMEWORK_LIBS_DATA_TYPES_SRC_CONTAINERS_BLOCK_HEADER_HPP_

--- a/libs/data_types/src/containers/message.hpp
+++ b/libs/data_types/src/containers/message.hpp
@@ -1,0 +1,58 @@
+#ifndef ZKEMV_FRAMEWORK_LIBS_DATA_TYPES_SRC_CONTAINERS_MESSAGE_HPP_
+#define ZKEMV_FRAMEWORK_LIBS_DATA_TYPES_SRC_CONTAINERS_MESSAGE_HPP_
+
+#include <cstdint>
+
+#include "containers/transaction.hpp"
+#include "sszpp/ssz++.hpp"
+#include "zkevm_framework/data_types/base.hpp"
+#include "zkevm_framework/data_types/message.hpp"
+
+namespace data_types {
+    namespace containers {
+        struct CommonMsgInfoContainer : ssz::ssz_container {
+            Address m_src;
+            Address m_dst;
+            size_t m_value;
+
+            SSZ_CONT(m_src, m_dst, m_value)
+
+            CommonMsgInfoContainer() {}
+
+            CommonMsgInfoContainer(const CommonMsgInfo& info)
+                : m_src(info.m_src), m_dst(info.m_dst), m_value(info.m_value) {}
+
+            operator CommonMsgInfo() const { return CommonMsgInfo(m_src, m_dst, m_value); }
+        };
+
+        struct InMsgContainer : ssz::ssz_variable_size_container {
+            CommonMsgInfoContainer m_info;
+            TransactionContainer m_transaction;
+
+            SSZ_CONT(m_info, m_transaction)
+
+            InMsgContainer() {}
+
+            InMsgContainer(const InMsg& msg)
+                : m_info(msg.m_info), m_transaction(msg.m_transaction) {}
+
+            operator InMsg() const { return InMsg(m_info, m_transaction); }
+        };
+
+        struct OutMsgContainer : ssz::ssz_variable_size_container {
+            CommonMsgInfoContainer m_info;
+            TransactionContainer m_transaction;
+
+            SSZ_CONT(m_info, m_transaction)
+
+            OutMsgContainer() {}
+
+            OutMsgContainer(const OutMsg& msg)
+                : m_info(msg.m_info), m_transaction(msg.m_transaction) {}
+
+            operator OutMsg() const { return OutMsg(m_info, m_transaction); }
+        };
+    }  // namespace containers
+}  // namespace data_types
+
+#endif  // ZKEMV_FRAMEWORK_LIBS_DATA_TYPES_SRC_CONTAINERS_MESSAGE_HPP_

--- a/libs/data_types/src/containers/state.hpp
+++ b/libs/data_types/src/containers/state.hpp
@@ -1,0 +1,72 @@
+#ifndef ZKEMV_FRAMEWORK_LIBS_DATA_TYPES_SRC_CONTAINERS_STATE_HPP_
+#define ZKEMV_FRAMEWORK_LIBS_DATA_TYPES_SRC_CONTAINERS_STATE_HPP_
+
+#include <cstdint>
+
+#include "containers/account.hpp"
+#include "containers/message.hpp"
+#include "sszpp/ssz++.hpp"
+#include "zkevm_framework/data_types/account.hpp"
+#include "zkevm_framework/data_types/message.hpp"
+#include "zkevm_framework/data_types/mpt.hpp"
+#include "zkevm_framework/data_types/state.hpp"
+
+namespace data_types {
+    namespace containers {
+        struct StateContainer : ssz::ssz_variable_size_container {
+            uint64_t m_globalId;
+            uint64_t m_shardId;
+            uint32_t m_seqNo;
+            uint64_t m_vertSeqNo;
+            size_t m_genLt;
+            uint32_t m_minRefMcSeqno;
+            bool m_beforeSplit;
+            uint32_t m_genUtime;
+            uint32_t m_totalBalance;
+            uint32_t m_totalValidatorFees;
+            ssz::list<OutMsgContainer, 100> m_outMsg;
+            ssz::list<AccountContainer, 100> m_accounts;
+
+            SSZ_CONT(m_globalId, m_shardId, m_seqNo, m_vertSeqNo, m_genLt, m_minRefMcSeqno,
+                     m_beforeSplit, m_genUtime, m_totalBalance, m_totalValidatorFees, m_outMsg,
+                     m_accounts)
+
+            StateContainer() {}
+
+            StateContainer(const State &state)
+                : m_globalId(state.m_globalId),
+                  m_shardId(state.m_shardId),
+                  m_seqNo(state.m_seqNo),
+                  m_vertSeqNo(state.m_vertSeqNo),
+                  m_genLt(state.m_genLt),
+                  m_minRefMcSeqno(state.m_minRefMcSeqno),
+                  m_beforeSplit(state.m_beforeSplit),
+                  m_genUtime(state.m_genUtime),
+                  m_totalBalance(state.m_totalBalance),
+                  m_totalValidatorFees(state.m_totalValidatorFees) {
+                for (const OutMsg &out_msg : state.m_outMsg) {
+                    m_outMsg.push_back(OutMsgContainer(out_msg));
+                }
+                for (const Account &account : state.m_accounts) {
+                    m_accounts.push_back(AccountContainer(account));
+                }
+            }
+
+            operator State() const {
+                MPTNode<OutMsg> outMsg;
+                for (const OutMsgContainer &msg : m_outMsg) {
+                    outMsg.push_back(static_cast<OutMsg>(msg));
+                }
+                MPTNode<Account> accounts;
+                for (const AccountContainer &account : m_accounts) {
+                    accounts.push_back(static_cast<Account>(account));
+                }
+                return State(m_globalId, m_shardId, m_seqNo, m_vertSeqNo, m_genLt, m_minRefMcSeqno,
+                             m_beforeSplit, m_genUtime, m_totalBalance, m_totalValidatorFees,
+                             outMsg, accounts);
+            }
+        };
+    }  // namespace containers
+}  // namespace data_types
+
+#endif  // ZKEMV_FRAMEWORK_LIBS_DATA_TYPES_SRC_CONTAINERS_STATE_HPP_

--- a/libs/data_types/src/containers/transaction.hpp
+++ b/libs/data_types/src/containers/transaction.hpp
@@ -1,0 +1,48 @@
+#ifndef ZKEMV_FRAMEWORK_LIBS_DATA_TYPES_SRC_CONTAINERS_TRANSACTION_HPP_
+#define ZKEMV_FRAMEWORK_LIBS_DATA_TYPES_SRC_CONTAINERS_TRANSACTION_HPP_
+
+#include <cstddef>
+#include <cstdint>
+
+#include "sszpp/ssz++.hpp"
+#include "zkevm_framework/data_types/base.hpp"
+#include "zkevm_framework/data_types/transaction.hpp"
+
+namespace data_types {
+    namespace containers {
+        struct TransactionContainer : ssz::ssz_variable_size_container {
+            size_t m_id;
+            uint8_t m_type;
+            size_t m_nonce;
+            size_t m_value;
+            Address m_receiveAddress;
+            size_t m_gasPrice;
+            size_t m_gas;
+            ssz::list<std::byte, 100> m_data;
+            Address m_sender;
+
+            SSZ_CONT(m_id, m_type, m_nonce, m_value, m_receiveAddress, m_gasPrice, m_gas, m_data,
+                     m_sender)
+
+            TransactionContainer() {}
+
+            TransactionContainer(const Transaction& transaction)
+                : m_id(transaction.m_id),
+                  m_nonce(transaction.m_nonce),
+                  m_value(transaction.m_value),
+                  m_receiveAddress(transaction.m_receiveAddress),
+                  m_gasPrice(transaction.m_gasPrice),
+                  m_gas(transaction.m_gas),
+                  m_sender(transaction.m_sender),
+                  m_type(transaction.m_type),
+                  m_data(transaction.m_data) {}
+
+            operator Transaction() const {
+                return Transaction(m_id, static_cast<Transaction::Type>(m_type), m_nonce, m_value,
+                                   m_receiveAddress, m_gasPrice, m_gas, m_data.data(), m_sender);
+            }
+        };
+    }  // namespace containers
+}  // namespace data_types
+
+#endif  // ZKEMV_FRAMEWORK_LIBS_DATA_TYPES_SRC_CONTAINERS_TRANSACTION_HPP_

--- a/libs/data_types/src/containers/transaction_receipt.hpp
+++ b/libs/data_types/src/containers/transaction_receipt.hpp
@@ -1,0 +1,35 @@
+#ifndef ZKEMV_FRAMEWORK_LIBS_DATA_TYPES_SRC_CONTAINERS_TRANSACTION_RECEIPT_HPP_
+#define ZKEMV_FRAMEWORK_LIBS_DATA_TYPES_SRC_CONTAINERS_TRANSACTION_RECEIPT_HPP_
+
+#include <cstdint>
+
+#include "sszpp/ssz++.hpp"
+#include "zkevm_framework/data_types/base.hpp"
+#include "zkevm_framework/data_types/transaction.hpp"
+#include "zkevm_framework/data_types/transaction_receipt.hpp"
+
+namespace data_types {
+    namespace containers {
+        struct TransactionReceiptContainer : ssz::ssz_container {
+            uint8_t m_type;
+            Hash m_stateRoot;
+            size_t m_gasUsed;
+
+            SSZ_CONT(m_type, m_stateRoot, m_gasUsed)
+
+            TransactionReceiptContainer() {}
+
+            TransactionReceiptContainer(const TransactionReceipt& receipt)
+                : m_type(receipt.m_type),
+                  m_stateRoot(receipt.m_stateRoot),
+                  m_gasUsed(receipt.m_gasUsed) {}
+
+            operator TransactionReceipt() const {
+                return TransactionReceipt(static_cast<Transaction::Type>(m_type), m_stateRoot,
+                                          m_gasUsed);
+            }
+        };
+    }  // namespace containers
+}  // namespace data_types
+
+#endif  // ZKEMV_FRAMEWORK_LIBS_DATA_TYPES_SRC_CONTAINERS_TRANSACTION_RECEIPT_HPP_

--- a/libs/data_types/src/message.cpp
+++ b/libs/data_types/src/message.cpp
@@ -1,26 +1,27 @@
 #include "zkevm_framework/data_types/message.hpp"
 
+#include "containers/message.hpp"
 #include "sszpp/ssz++.hpp"
 #include "zkevm_framework/data_types/base.hpp"
 
 namespace data_types {
-    bytes CommonMsgInfo::serialize() const {
-        return ssz::serialize<CommonMsgInfo::Serializable>(*this);
-    }
+    using namespace containers;
+
+    bytes CommonMsgInfo::serialize() const { return ssz::serialize<CommonMsgInfoContainer>(*this); }
 
     CommonMsgInfo CommonMsgInfo::deserialize(const bytes& src) {
-        return ssz::deserialize<CommonMsgInfo::Serializable>(src);
+        return static_cast<CommonMsgInfo>(ssz::deserialize<CommonMsgInfoContainer>(src));
     }
 
-    bytes InMsg::serialize() const { return ssz::serialize<InMsg::Serializable>(*this); }
+    bytes InMsg::serialize() const { return ssz::serialize<InMsgContainer>(*this); }
 
     InMsg InMsg::deserialize(const bytes& src) {
-        return ssz::deserialize<InMsg::Serializable>(src);
+        return static_cast<InMsg>(ssz::deserialize<InMsgContainer>(src));
     }
 
-    bytes OutMsg::serialize() const { return ssz::serialize<OutMsg::Serializable>(*this); }
+    bytes OutMsg::serialize() const { return ssz::serialize<OutMsgContainer>(*this); }
 
     OutMsg OutMsg::deserialize(const bytes& src) {
-        return ssz::deserialize<OutMsg::Serializable>(src);
+        return static_cast<OutMsg>(ssz::deserialize<OutMsgContainer>(src));
     }
 }  // namespace data_types

--- a/libs/data_types/src/state.cpp
+++ b/libs/data_types/src/state.cpp
@@ -1,52 +1,15 @@
 #include "zkevm_framework/data_types/state.hpp"
 
+#include "containers/state.hpp"
 #include "sszpp/ssz++.hpp"
-#include "zkevm_framework/data_types/account.hpp"
 #include "zkevm_framework/data_types/base.hpp"
-#include "zkevm_framework/data_types/message.hpp"
 
 namespace data_types {
-    State::Serializable::Serializable(const State &state)
-        : m_globalId(state.m_globalId),
-          m_shardId(state.m_shardId),
-          m_seqNo(state.m_seqNo),
-          m_vertSeqNo(state.m_vertSeqNo),
-          m_genLt(state.m_genLt),
-          m_minRefMcSeqno(state.m_minRefMcSeqno),
-          m_beforeSplit(state.m_beforeSplit),
-          m_genUtime(state.m_genUtime),
-          m_totalBalance(state.m_totalBalance),
-          m_totalValidatorFees(state.m_totalValidatorFees) {
-        for (const OutMsg &out_msg : state.m_outMsg) {
-            m_outMsg.push_back(OutMsg::Serializable(out_msg));
-        }
-        for (const Account &account : state.m_accounts) {
-            m_accounts.push_back(Account::Serializable(account));
-        }
-    }
+    using namespace containers;
 
-    State::State(const State::Serializable &s)
-        : m_globalId(s.m_globalId),
-          m_shardId(s.m_shardId),
-          m_seqNo(s.m_seqNo),
-          m_vertSeqNo(s.m_vertSeqNo),
-          m_genLt(s.m_genLt),
-          m_minRefMcSeqno(s.m_minRefMcSeqno),
-          m_beforeSplit(s.m_beforeSplit),
-          m_genUtime(s.m_genUtime),
-          m_totalBalance(s.m_totalBalance),
-          m_totalValidatorFees(s.m_totalValidatorFees) {
-        for (const OutMsg::Serializable &out_msg : s.m_outMsg) {
-            m_outMsg.push_back(OutMsg(out_msg));
-        }
-        for (const Account::Serializable &account : s.m_accounts) {
-            m_accounts.push_back(Account(account));
-        }
-    }
-
-    bytes State::serialize() const { return ssz::serialize<State::Serializable>(*this); }
+    bytes State::serialize() const { return ssz::serialize<StateContainer>(*this); }
 
     State State::deserialize(const bytes &src) {
-        return ssz::deserialize<State::Serializable>(src);
+        return static_cast<State>(ssz::deserialize<StateContainer>(src));
     }
 }  // namespace data_types

--- a/libs/data_types/src/transaction.cpp
+++ b/libs/data_types/src/transaction.cpp
@@ -1,14 +1,15 @@
 #include "zkevm_framework/data_types/transaction.hpp"
 
+#include "containers/transaction.hpp"
 #include "sszpp/ssz++.hpp"
 #include "zkevm_framework/data_types/base.hpp"
 
 namespace data_types {
-    bytes Transaction::serialize() const {
-        return ssz::serialize<Transaction::Serializable>(*this);
-    }
+    using namespace containers;
+
+    bytes Transaction::serialize() const { return ssz::serialize<TransactionContainer>(*this); }
 
     Transaction Transaction::deserialize(const bytes &src) {
-        return ssz::deserialize<Transaction::Serializable>(src);
+        return static_cast<Transaction>(ssz::deserialize<TransactionContainer>(src));
     }
 }  // namespace data_types

--- a/libs/data_types/src/transaction_receipt.cpp
+++ b/libs/data_types/src/transaction_receipt.cpp
@@ -1,14 +1,17 @@
 #include "zkevm_framework/data_types/transaction_receipt.hpp"
 
+#include "containers/transaction_receipt.hpp"
 #include "sszpp/ssz++.hpp"
 #include "zkevm_framework/data_types/base.hpp"
 
 namespace data_types {
+    using namespace containers;
+
     bytes TransactionReceipt::serialize() const {
-        return ssz::serialize<TransactionReceipt::Serializable>(*this);
+        return ssz::serialize<TransactionReceiptContainer>(*this);
     }
 
     TransactionReceipt TransactionReceipt::deserialize(const bytes& src) {
-        return ssz::deserialize<TransactionReceipt::Serializable>(src);
+        return static_cast<TransactionReceipt>(ssz::deserialize<TransactionReceiptContainer>(src));
     }
 }  // namespace data_types


### PR DESCRIPTION
This avoids exposing `sszpp` headers in public data types headers. As a result, users don't need to have `sszpp` headers installed to use data types.

This PR contains pretty much changes, which are mostly organizational. It makes sense just to pull this branch and see how it looks now.

The key idea here: remove `#include "sszpp/ssz++.hpp"` from public headers of Data types