### PR TITLE
Change inputs of dev shell to be native

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -136,6 +136,7 @@
         in
         pkgs.mkShell {
           nativeBuildInputs = with pkgs; [
+            gcc13
             cmake
             ninja
             boost


### PR DESCRIPTION
Without that `gcc` e.g. is not exposed properly and can be set to 12 version, which is undesirable.