### PR TITLE
Fix bug in reading input block file

### DIFF
--- a/bin/assigner/include/utils.hpp
+++ b/bin/assigner/include/utils.hpp
@@ -1,9 +1,12 @@
 #ifndef ZKEMV_FRAMEWORK_BIN_ASSIGNER_INCLUDE_UTILS_HPP_
 #define ZKEMV_FRAMEWORK_BIN_ASSIGNER_INCLUDE_UTILS_HPP_
 
-#include <execution_state.hpp>
-#include <vm.hpp>
+#include <fstream>
+#include <iostream>
+#include <map>
 
+#include "execution_state.hpp"
+#include "vm.hpp"
 #include "zkevm_framework/data_types/base.hpp"
 #include "zkevm_framework/data_types/block.hpp"
 


### PR DESCRIPTION
`tellg()` was returning `0` because the current position is set to begin after opening file. Because of that `read()` was reading 0 bytes, which was leading to segmentation fault on de-serialization.

Now we set cursor to the end of the file to get its size with `tellg()` and then set it back to beginning before read.