### PR TITLE
Small README fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,8 +88,7 @@ Same option applies to `nix build` and etc.
 ## Build
 
 ```plain
-cmake --preset release
-cmake --build --preset release
+cmake --workflow --preset release-build
 ```
 
 Or with Nix:


### PR DESCRIPTION
Clone section was weirdly located in the middle of Nix env description. I guess, it ended up there by mistake (maybe during some merge conflict resolving). Moved it to the beginning, because you start everything with cloning.

Also slightly simplifies build command with CMake workflow presets: you can build with 1 command instead of 2 commands.