### PR TITLE
Import evm-assigner targets

### DIFF
--- a/.github/scripts/pure_cmake_build.sh
+++ b/.github/scripts/pure_cmake_build.sh
@@ -1,0 +1,14 @@
+#!/bin/bash -e
+
+nix develop -c "env" | grep CMAKE_PREFIX_PATH >cmake_prefix
+echo "export `cat cmake_prefix`" > cmake_prefix
+source cmake_prefix
+cat cmake_prefix
+rm cmake_prefix
+CMAKE_BINARY=$(nix develop -c bash -c 'which cmake' | tail -1)
+NINJA_BINARY=$(nix develop -c bash -c 'which ninja' | tail -1)
+CC=$(nix develop -c bash -c 'which gcc' | tail -1)
+CXX=$(nix develop -c bash -c 'which g++' | tail -1)
+set -x
+$CMAKE_BINARY -GNinja -DCMAKE_MAKE_PROGRAM=$NINJA_BINARY -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=$CC -DCMAKE_CXX_COMPILER=$CXX -DENABLE_TESTS=TRUE
+$NINJA_BINARY -C build

--- a/.github/workflows/run-tests-linux.yml
+++ b/.github/workflows/run-tests-linux.yml
@@ -40,3 +40,6 @@ jobs:
 
       - name: Run checks
         run: nix flake -L check
+
+      - name: Check build without nix environment
+        run: .github/scripts/pure_cmake_build.sh

--- a/bin/assigner/CMakeLists.txt
+++ b/bin/assigner/CMakeLists.txt
@@ -6,6 +6,8 @@ set(SOURCES
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 
+find_package(evm-assigner REQUIRED)
+
 add_executable(${TARGET_NAME} ${SOURCES})
 
 target_include_directories(${TARGET_NAME}
@@ -15,7 +17,7 @@ target_include_directories(${TARGET_NAME}
 
 target_link_libraries(${TARGET_NAME}
     PRIVATE
-    evmone_assigner
+    evm-assigner::evm-assigner
     zkEVMAssignerRunner
     zkEVMDataTypes
     zkEVMJsonHelpers

--- a/bin/emulator/CMakeLists.txt
+++ b/bin/emulator/CMakeLists.txt
@@ -15,9 +15,10 @@ target_include_directories(${TARGET_NAME}
 
 target_compile_options(${TARGET_NAME} PRIVATE "-fPIC")
 
+find_package(evm-assigner REQUIRED)
 target_link_libraries(${TARGET_NAME}
     PRIVATE
-    evmone_assigner
+    evm-assigner::evm-assigner
     zkEVMAssignerRunner
     zkEVMDataTypes
     zkEVMJsonHelpers

--- a/flake.lock
+++ b/flake.lock
@@ -25,11 +25,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1712603294,
-        "narHash": "sha256-0L7ir0E+jFv9dxmLV6Vxlf+st6BNaJrhRXyNCK3xPsY=",
+        "lastModified": 1717659149,
+        "narHash": "sha256-aWvONWN0Q7Kx6NDvwpeydO1GpdlinI5RwPlaQly9HsA=",
         "ref": "refs/heads/master",
-        "rev": "13909af052a998c92d2a6a96e0bcfd21156aed72",
-        "revCount": 701,
+        "rev": "73ded556ea77147ce7afd3dbeed8e21f5f4d81db",
+        "revCount": 9117,
         "submodules": true,
         "type": "git",
         "url": "https://github.com/NilFoundation/crypto3"
@@ -59,11 +59,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1717676550,
-        "narHash": "sha256-W+gFcdI+b+e5uCN5OxyUJmaVriEidfbEpwLHykwziWE=",
+        "lastModified": 1718020114,
+        "narHash": "sha256-7FuVcu9cvG0rsbXrR+Cs0rl3mdBlwN77p3MCoDEUgB4=",
         "owner": "NilFoundation",
         "repo": "evm-assigner",
-        "rev": "073cd2a4ad32f051b4ea1ea1e5ffc028f0ab80f0",
+        "rev": "d5cd7c05bb92bc2f6eec86553be7d81ae1122e5c",
         "type": "github"
       },
       "original": {
@@ -74,6 +74,9 @@
     },
     "nil-zkllvm-blueprint": {
       "inputs": {
+        "flake-utils": [
+          "flake-utils"
+        ],
         "nil_crypto3": [
           "nil-crypto3"
         ],
@@ -82,11 +85,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1716471481,
-        "narHash": "sha256-08+2vMX/+uD/Sk4mMo5/86P6GSAeNqxvitWcXxwXP8s=",
+        "lastModified": 1717666696,
+        "narHash": "sha256-/hDnXfn4mrmhfP89ZRBf7TRqISkTqxbZhdZc2oqBDko=",
         "ref": "refs/heads/master",
-        "rev": "54a897574f3e2da1d049c83e52fa97d8ae935595",
-        "revCount": 1211,
+        "rev": "8a3c4059616b0dd2183506e7ec8740e584ea443a",
+        "revCount": 1230,
         "submodules": true,
         "type": "git",
         "url": "https://github.com/NilFoundation/zkllvm-blueprint"

--- a/flake.nix
+++ b/flake.nix
@@ -37,6 +37,7 @@
       submodules = true;
       inputs = {
         nixpkgs.follows = "nixpkgs";
+        flake-utils.follows = "flake-utils";
         nil_crypto3.follows = "nil-crypto3";
       };
     };

--- a/libs/assigner_runner/CMakeLists.txt
+++ b/libs/assigner_runner/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_library(zkEVMAssignerRunner STATIC
+add_library(zkEVMAssignerRunner SHARED
             src/runner.cpp
             src/utils.cpp
             src/state_parser.cpp

--- a/libs/assigner_runner/CMakeLists.txt
+++ b/libs/assigner_runner/CMakeLists.txt
@@ -14,16 +14,17 @@ target_include_directories(zkEVMAssignerRunner
 )
 
 find_package(Boost COMPONENTS REQUIRED log random)
+find_package(evm-assigner REQUIRED)
 target_link_libraries(zkEVMAssignerRunner
                         PUBLIC
-                        evmone_assigner
+                        evm-assigner::evm-assigner
                         zkEVMDataTypes
                         zkEVMJsonHelpers
                         zkEVMOutputArtifacts
                         Boost::log
                         Boost::random
                         PRIVATE
-                        evmone
+                        evm-assigner::evmone
 )
 
 install(TARGETS zkEVMAssignerRunner

--- a/libs/block_generator/CMakeLists.txt
+++ b/libs/block_generator/CMakeLists.txt
@@ -1,7 +1,7 @@
 include(SchemaHelper)
 generate_schema_include(block_schema_include resources/block_schema.json)
 
-add_library(zkEVMBlockGenerator STATIC block_generator.cpp)
+add_library(zkEVMBlockGenerator SHARED block_generator.cpp)
 add_dependencies(zkEVMBlockGenerator block_schema_include)
 
 find_package(Boost COMPONENTS REQUIRED json)

--- a/libs/data_types/CMakeLists.txt
+++ b/libs/data_types/CMakeLists.txt
@@ -1,6 +1,6 @@
 set(LIBRARY_NAME zkEVMDataTypes)
 
-add_library(${LIBRARY_NAME} STATIC)
+add_library(${LIBRARY_NAME} SHARED)
 
 # SSZ++ requires C++23, also DataTypes is using <expected>
 # This feature will be propagated to all targets linked with the library

--- a/libs/json_helpers/CMakeLists.txt
+++ b/libs/json_helpers/CMakeLists.txt
@@ -1,7 +1,7 @@
 find_package(valijson REQUIRED)
 find_package(Boost COMPONENTS REQUIRED json)
 
-add_library(zkEVMJsonHelpers STATIC json_helpers.cpp)
+add_library(zkEVMJsonHelpers SHARED json_helpers.cpp)
 target_link_libraries(zkEVMJsonHelpers PUBLIC ${Boost_LIBRARIES} PRIVATE valijson)
 target_include_directories(zkEVMJsonHelpers PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
 target_compile_features(zkEVMJsonHelpers PUBLIC cxx_std_23)

--- a/libs/output_artifacts/CMakeLists.txt
+++ b/libs/output_artifacts/CMakeLists.txt
@@ -1,12 +1,12 @@
-find_package(Boost COMPONENTS REQUIRED log log_setup program_options regex)
+find_package(Boost COMPONENTS REQUIRED program_options regex)
 
 set(LIBRARY_NAME zkEVMOutputArtifacts)
 
-add_library(${LIBRARY_NAME} STATIC src/output_artifacts.cpp)
+add_library(${LIBRARY_NAME} SHARED src/output_artifacts.cpp)
 
 target_compile_features(${LIBRARY_NAME} PUBLIC cxx_std_23)
 
-target_link_libraries(${LIBRARY_NAME} PRIVATE ${Boost_LIBRARIES})
+target_link_libraries(${LIBRARY_NAME} PUBLIC Boost::program_options PRIVATE Boost::regex)
 
 target_include_directories(${LIBRARY_NAME} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
 


### PR DESCRIPTION
I had to make all the libraries shared because wrapper library compiled with `-fPIC` requires all the dependencies to be built with this option. Have no idea how it was working under Nix.