### PR TITLE
Clear Nix compiler flags before build

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -111,6 +111,22 @@
 
         src = self;
 
+        # This is a hack to avoid Nix forcing -L and -isystem flags to the compiler.
+        # See: https://nixos.wiki/wiki/C
+        # Whithout this Nix will call the compiler in such way, that most of CMake
+        # include and link flags will have no effect.
+        preConfigure = ''
+          echo "Filtering NIX_LDFLAGS and NIX_CFLAGS_COMPILE"
+          echo "Before:"
+          echo "  NIX_LDFLAGS=$NIX_LDFLAGS"
+          echo "  NIX_CFLAGS_COMPILE=$NIX_CFLAGS_COMPILE"
+          export NIX_LDFLAGS=$(echo $NIX_LDFLAGS | bash scripts/clear_gcc_flags.sh)
+          export NIX_CFLAGS_COMPILE=$(echo $NIX_CFLAGS_COMPILE | bash scripts/clear_gcc_flags.sh)
+          echo "After:"
+          echo "  NIX_LDFLAGS=$NIX_LDFLAGS"
+          echo "  NIX_CFLAGS_COMPILE=$NIX_CFLAGS_COMPILE"
+        '';
+
         cmakeBuildType = "Release";
 
         doCheck = false;

--- a/scripts/clear_gcc_flags.sh
+++ b/scripts/clear_gcc_flags.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+# This script is designed to clear -L and -isystem flags
+# from env vars NIX_LDFLAGS and NIX_CFLAGS_COMPILE
+
+read FLAGS
+
+FLAGS_ARRAY=($FLAGS)
+
+CLEAR_FLAGS=()
+
+startswith() { case $2 in "$1"*) true ;; *) false ;; esac }
+
+PREV_WAS_ISYSTEM=false
+
+for FLAG in "${FLAGS_ARRAY[@]}"; do
+    :
+    # If flag starts with "-L", skip it
+    if startswith -L "$FLAG"; then
+        continue
+    fi
+
+    # If flag equals to "-isystem", skip it and skip next one too
+    if [[ "$FLAG" == "-isystem" ]]; then
+        PREV_WAS_ISYSTEM=true
+        continue
+    fi
+
+    # If previous flag was "-isystem", skip it
+    if [ "$PREV_WAS_ISYSTEM" = true ]; then
+        PREV_WAS_ISYSTEM=false
+        continue
+    fi
+
+    # If flag passed all previous checks, add it
+    CLEAR_FLAGS+=($FLAG)
+done
+
+echo "${CLEAR_FLAGS[@]}"


### PR DESCRIPTION
This is a hack, which is required to properly delegate to CMake all the dependency resolving.

We already faced an issue with different versions of Boost being passed to compiler in improper manner. As a result,
build under Nix failed at linking (non-Nix build was completely fine at the same time). That happened, because Nix compiler wrapper was taking headers from one version of Boost and static libraries from another version of Boost.