### PR TITLE
Remove explicit Boost build input in `flake.nix`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -86,7 +86,6 @@
 
       defaultBuildInputs = { enableDebug ? false }: [
         # Default nixpkgs packages
-        pkgs.boost
         pkgs.python3
         pkgs.python311Packages.jsonschema
         pkgs.solc
@@ -98,6 +97,8 @@
         (evm_assigner { inherit enableDebug; })
         crypto3
         blueprint
+        # Blueprint will propagate Boost library.
+        # We don't include it here explicitly to reuse the same version.
         cluster
       ];
 


### PR DESCRIPTION
The idea here is that we want to use the same version of Boost as Blueprint (and Crypto3) does to avoid conflicts. That's why we remove explicit build input and rely on `propagatedBuildInputs` of Blueprint. If one day Blueprint will stop propagating Boost (although I don't see how its possible), we will have to revert this.