### PR TITLE
Some changes in flake.nix

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -18,24 +18,6 @@
         "type": "github"
       }
     },
-    "flake-utils_2": {
-      "inputs": {
-        "systems": "systems_2"
-      },
-      "locked": {
-        "lastModified": 1710146030,
-        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
     "nil-cluster": {
       "inputs": {
         "flake-utils": [
@@ -61,7 +43,9 @@
     },
     "nil-crypto3": {
       "inputs": {
-        "nix-3rdparty": "nix-3rdparty",
+        "nix-3rdparty": [
+          "nix-3rdparty"
+        ],
         "nixpkgs": [
           "nixpkgs"
         ]
@@ -72,14 +56,14 @@
         "ref": "refs/heads/master",
         "rev": "3bd5b8df2091274abaa28fd86b9e3e89d661b95a",
         "revCount": 9150,
-        "submodules": true,
         "type": "git",
         "url": "https://github.com/NilFoundation/crypto3"
       },
       "original": {
-        "submodules": true,
-        "type": "git",
-        "url": "https://github.com/NilFoundation/crypto3"
+        "owner": "NilFoundation",
+        "repo": "crypto3",
+        "rev": "3bd5b8df2091274abaa28fd86b9e3e89d661b95a",
+        "type": "github"
       }
     },
     "nil-evm-assigner": {
@@ -137,34 +121,13 @@
         "url": "https://github.com/NilFoundation/zkllvm-blueprint"
       },
       "original": {
+        "rev": "73d6a40e39b6b6fc7b1c84441e62337206dc0815",
         "submodules": true,
         "type": "git",
         "url": "https://github.com/NilFoundation/zkllvm-blueprint"
       }
     },
     "nix-3rdparty": {
-      "inputs": {
-        "flake-utils": "flake-utils_2",
-        "nixpkgs": [
-          "nil-crypto3",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1717519917,
-        "narHash": "sha256-GqzEqEW4Uz9Z7uDZwers0t9seWRNbRWPNE3OJnjE1Uw=",
-        "owner": "NilFoundation",
-        "repo": "nix-3rdparty",
-        "rev": "a2e45429aa25a4a6e8e362ef17df6f197312f224",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NilFoundation",
-        "repo": "nix-3rdparty",
-        "type": "github"
-      }
-    },
-    "nix-3rdparty_2": {
       "inputs": {
         "flake-utils": [
           "flake-utils"
@@ -209,26 +172,11 @@
         "nil-crypto3": "nil-crypto3",
         "nil-evm-assigner": "nil-evm-assigner",
         "nil-zkllvm-blueprint": "nil-zkllvm-blueprint",
-        "nix-3rdparty": "nix-3rdparty_2",
+        "nix-3rdparty": "nix-3rdparty",
         "nixpkgs": "nixpkgs"
       }
     },
     "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
-    "systems_2": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",

--- a/flake.nix
+++ b/flake.nix
@@ -37,6 +37,8 @@
       repo = "crypto3";
       inputs = {
         nixpkgs.follows = "nixpkgs";
+        flake-utils.follows = "flake-utils";
+        nix-3rdparty.follows = "nix-3rdparty";
       };
     };
     nil-zkllvm-blueprint = {

--- a/flake.nix
+++ b/flake.nix
@@ -35,6 +35,7 @@
       type = "github";
       owner = "NilFoundation";
       repo = "crypto3";
+      rev = "3bd5b8df2091274abaa28fd86b9e3e89d661b95a";
       inputs = {
         nixpkgs.follows = "nixpkgs";
         flake-utils.follows = "flake-utils";
@@ -45,6 +46,7 @@
       url = "https://github.com/NilFoundation/zkllvm-blueprint";
       type = "git";
       submodules = true;
+      rev = "73d6a40e39b6b6fc7b1c84441e62337206dc0815";
       inputs = {
         nixpkgs.follows = "nixpkgs";
         flake-utils.follows = "flake-utils";

--- a/flake.nix
+++ b/flake.nix
@@ -32,9 +32,9 @@
       };
     };
     nil-crypto3 = {
-      url = "https://github.com/NilFoundation/crypto3";
-      type = "git";
-      submodules = true;
+      type = "github";
+      owner = "NilFoundation";
+      repo = "crypto3";
       inputs = {
         nixpkgs.follows = "nixpkgs";
       };


### PR DESCRIPTION
Some minor changes to `flake.nix`:

- Remove unnecessary `submodules` parameter from crypto3 input (crypto3 no longer has submodules)
- Change crypto3 input type to `github` (since there are no submodules, we don't need `git` input type here)
- Add some `follows` params to crypto3 inputs to reduce different revisions when locking dependencies
- Pin crypto3 and blueprint revisions explicitly in `flake.nix`. This will allow us to control their versions more precisely and avoid accidental updates to unsupported versions.