### PR TITLE
Remove explicit `Boost::random` from assigner runner

### DIFF
--- a/libs/assigner_runner/CMakeLists.txt
+++ b/libs/assigner_runner/CMakeLists.txt
@@ -13,7 +13,7 @@ target_include_directories(zkEVMAssignerRunner
                             PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/include
 )
 
-find_package(Boost COMPONENTS REQUIRED log random)
+find_package(Boost COMPONENTS REQUIRED log)
 find_package(evm-assigner REQUIRED)
 target_link_libraries(zkEVMAssignerRunner
                         PUBLIC

--- a/libs/assigner_runner/CMakeLists.txt
+++ b/libs/assigner_runner/CMakeLists.txt
@@ -22,7 +22,6 @@ target_link_libraries(zkEVMAssignerRunner
                         zkEVMJsonHelpers
                         zkEVMOutputArtifacts
                         Boost::log
-                        Boost::random
 )
 
 install(TARGETS zkEVMAssignerRunner


### PR DESCRIPTION
This link is no longer needed, because blueprint now exports this library properly.

See:

- NilFoundation/zkllvm-blueprint/pull/411