### PR TITLE
Refactor `flake.nix`

### DIFF
--- a/.github/workflows/run-tests-linux.yml
+++ b/.github/workflows/run-tests-linux.yml
@@ -32,9 +32,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Run build
-        run: nix build -L
-
       - name: Run checks
         run: nix flake -L check
 

--- a/flake.lock
+++ b/flake.lock
@@ -28,17 +28,17 @@
         ]
       },
       "locked": {
-        "lastModified": 1721840811,
-        "narHash": "sha256-RGsSO7rsGMJ22eoRjI/79ojzqniwv/ZA/Yy6Los76+I=",
+        "lastModified": 1723635404,
+        "narHash": "sha256-iY6HfDSVam3ga9h06PaY6mMWfUu0L9VuYaRGXksEHN8=",
         "ref": "refs/heads/main",
-        "rev": "9f4c875d95a208043f0569d1bba23d6310c89974",
-        "revCount": 969,
+        "rev": "37e1ccf2beea796fcd31d5fc91c5cf11c1a0c118",
+        "revCount": 1141,
         "type": "git",
-        "url": "https://github.com/NilFoundation/nil"
+        "url": "ssh://git@github.com/NilFoundation/nil"
       },
       "original": {
         "type": "git",
-        "url": "https://github.com/NilFoundation/nil"
+        "url": "ssh://git@github.com/NilFoundation/nil"
       }
     },
     "nil-crypto3": {

--- a/flake.lock
+++ b/flake.lock
@@ -28,11 +28,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1723635404,
-        "narHash": "sha256-iY6HfDSVam3ga9h06PaY6mMWfUu0L9VuYaRGXksEHN8=",
+        "lastModified": 1723732583,
+        "narHash": "sha256-a1C/eTLzrqkLpHjYKhCScvbckcBjL6UP/vLPnaaVgXA=",
         "ref": "refs/heads/main",
-        "rev": "37e1ccf2beea796fcd31d5fc91c5cf11c1a0c118",
-        "revCount": 1141,
+        "rev": "e2858f2c137942d4fadde04d1dcef6613d6c44ff",
+        "revCount": 1158,
         "type": "git",
         "url": "ssh://git@github.com/NilFoundation/nil"
       },

--- a/flake.nix
+++ b/flake.nix
@@ -25,7 +25,7 @@
     };
     nil-cluster = {
       type = "git";  # 'git' is required here, for 'github' we cannot compute cluster version via git history
-      url = "https://github.com/NilFoundation/nil";
+      url = "ssh://git@github.com/NilFoundation/nil";
       inputs = {
         nixpkgs.follows = "nixpkgs";
         flake-utils.follows = "flake-utils";

--- a/zkevm-framework.nix
+++ b/zkevm-framework.nix
@@ -71,6 +71,11 @@ stdenv.mkDerivation {
 
   doCheck = enableTesting;
 
+  checkPhase = ''
+    ctest
+    ninja executables_tests
+  '';
+
   GTEST_OUTPUT = "xml:${placeholder "out"}/test-reports/";
 
   shellHook = ''

--- a/zkevm-framework.nix
+++ b/zkevm-framework.nix
@@ -1,0 +1,79 @@
+{ pkgs
+, lib
+, stdenv
+, src_repo
+, cmake
+, ninja
+, gtest
+, solc
+, doxygen
+, clang_17
+, go_1_22
+, gotools
+, go-tools
+, gopls
+, golangci-lint
+, gofumpt
+, gci
+, python3
+, python312Packages
+, valijson
+, intx
+, sszpp
+, evmc
+, evm-assigner
+, crypto3
+, blueprint
+, cluster
+, enableTesting ? false
+, enableDebug ? false
+}:
+
+stdenv.mkDerivation {
+  name = "zkEVM-framework";
+
+  nativeBuildInputs = [
+    cmake
+    ninja
+    solc
+    python3
+    doxygen
+    clang_17 # clang-format and clang-tidy
+    go_1_22
+    gotools
+    go-tools
+    gopls
+    golangci-lint
+    gofumpt
+    gci
+  ];
+
+  buildInputs = [
+    gtest
+    python312Packages.jsonschema
+    valijson
+    crypto3
+    blueprint
+    cluster
+    (intx.override { inherit enableDebug; })
+    (sszpp.override { inherit enableDebug; })
+    (evmc.override { inherit enableDebug; })
+    (evm-assigner { inherit enableDebug; })
+  ];
+
+  src = src_repo;
+
+  cmakeBuildType = if enableDebug then "Debug" else "Release";
+
+  dontStrip = enableDebug;
+
+  cmakeFlags = if enableTesting then [ "-DENABLE_TESTS=TRUE" ] else [ ];
+
+  doCheck = enableTesting;
+
+  GTEST_OUTPUT = "xml:${placeholder "out"}/test-reports/";
+
+  shellHook = ''
+    echo "zkEVM-framework ${if enableDebug then "debug" else "release"} dev environment activated"
+  '';
+}


### PR DESCRIPTION
Some refactoring of flake file:

- Move derivation into separate file, simplify flake file;
- Removed explicit dev shells from flake file
- Remove unnecessary step in CI workflow;
- Remove `flake-utils` from Crypto3 input (because it's not used in the current revision of Crypto3. **However** it will have to be added later).

Most of the things work the same as previously. To activate dev debug shell, run:

```
nix develop .#debug
```

Some things which may be improved in the future:
- Refine Boost library propagation properly
- Refine the list of required Go tools (they were just copy-pasted, probably we don't need all of them)